### PR TITLE
Add dataset balancing utility

### DIFF
--- a/mdlt/dataset/datasets.py
+++ b/mdlt/dataset/datasets.py
@@ -490,9 +490,14 @@ class VLCS(MultipleEnvironmentImageFolder):
     MANY_SHOT_THRES = 100
     FEW_SHOT_THRES = 20
 
+    # If the environment variable ``MDLT_CSV_SUFFIX`` is set, the dataset will
+    # load ``VLCS${MDLT_CSV_SUFFIX}.csv`` instead of the default CSV.
+
     def __init__(self, root, split, hparams):
         self.dir = os.path.join(root, "VLCS")
-        self.df = pd.read_csv(os.path.join(self.dir, "VLCS.csv"))
+        csv_suffix = os.environ.get("MDLT_CSV_SUFFIX", "")
+        csv_name = f"VLCS{csv_suffix}.csv"
+        self.df = pd.read_csv(os.path.join(self.dir, csv_name))
         # self.df = pd.read_csv("/home/hyunggyu/imbalance/multi-domain-imbalance/mdlt/dataset/split/VLCS.csv")
         super().__init__(self.dir, self.df, split, hparams['data_augmentation'], hparams)
 
@@ -501,10 +506,13 @@ class PACS(MultipleEnvironmentImageFolder):
     ENVIRONMENTS = ["A", "C", "P", "S"]
     MANY_SHOT_THRES = 100
     FEW_SHOT_THRES = 20
+    # Use ``MDLT_CSV_SUFFIX`` to select ``PACS${MDLT_CSV_SUFFIX}.csv``
 
     def __init__(self, root, split, hparams):
         self.dir = os.path.join(root, "PACS")
-        self.df = pd.read_csv(os.path.join(self.dir, "PACS.csv"))
+        csv_suffix = os.environ.get("MDLT_CSV_SUFFIX", "")
+        csv_name = f"PACS{csv_suffix}.csv"
+        self.df = pd.read_csv(os.path.join(self.dir, csv_name))
         # self.df = pd.read_csv("/home/hyunggyu/imbalance/multi-domain-imbalance/mdlt/dataset/split/PACS.csv")
         super().__init__(self.dir, self.df, split, hparams['data_augmentation'], hparams)
 
@@ -515,10 +523,13 @@ class DomainNet(MultipleEnvironmentImageFolder):
     ENVIRONMENTS = ["clip", "info", "paint", "quick", "real", "sketch"]
     MANY_SHOT_THRES = 100
     FEW_SHOT_THRES = 20
+    # When ``MDLT_CSV_SUFFIX`` is set, ``DomainNet${MDLT_CSV_SUFFIX}.csv`` is used
 
     def __init__(self, root, split, hparams):
         self.dir = os.path.join(root, "domain_net")
-        self.df = pd.read_csv(os.path.join(self.dir, "DomainNet.csv"))
+        csv_suffix = os.environ.get("MDLT_CSV_SUFFIX", "")
+        csv_name = f"DomainNet{csv_suffix}.csv"
+        self.df = pd.read_csv(os.path.join(self.dir, csv_name))
         # self.df = pd.read_csv("/home/hyunggyu/imbalance/multi-domain-imbalance/mdlt/dataset/split/DomainNet.csv")
 
         super().__init__(self.dir, self.df, split, hparams['data_augmentation'], hparams)
@@ -528,10 +539,13 @@ class OfficeHome(MultipleEnvironmentImageFolder):
     ENVIRONMENTS = ["A", "C", "P", "R"]
     MANY_SHOT_THRES = 60
     FEW_SHOT_THRES = 20
+    # Load ``OfficeHome${MDLT_CSV_SUFFIX}.csv`` when the environment variable is set
 
     def __init__(self, root, split, hparams):
         self.dir = os.path.join(root, "office_home")
-        self.df = pd.read_csv(os.path.join(self.dir, "OfficeHome.csv"))
+        csv_suffix = os.environ.get("MDLT_CSV_SUFFIX", "")
+        csv_name = f"OfficeHome{csv_suffix}.csv"
+        self.df = pd.read_csv(os.path.join(self.dir, csv_name))
         # self.df = pd.read_csv("/home/hyunggyu/imbalance/multi-domain-imbalance/mdlt/dataset/split/OfficeHome.csv")
         
         super().__init__(self.dir, self.df, split, hparams['data_augmentation'], hparams)
@@ -541,9 +555,12 @@ class TerraIncognita(MultipleEnvironmentImageFolder):
     ENVIRONMENTS = ["L100", "L38", "L43", "L46"]
     MANY_SHOT_THRES = 100
     FEW_SHOT_THRES = 25
+    # ``MDLT_CSV_SUFFIX`` selects ``TerraIncognita${MDLT_CSV_SUFFIX}.csv``
 
     def __init__(self, root, split, hparams):
         self.dir = os.path.join(root, "terra_incognita")
-        self.df = pd.read_csv(os.path.join(self.dir, "TerraIncognita.csv"))
+        csv_suffix = os.environ.get("MDLT_CSV_SUFFIX", "")
+        csv_name = f"TerraIncognita{csv_suffix}.csv"
+        self.df = pd.read_csv(os.path.join(self.dir, csv_name))
         # self.df = pd.read_csv("/home/hyunggyu/imbalance/multi-domain-imbalance/mdlt/dataset/split/TerraIncognita.csv")
         super().__init__(self.dir, self.df, split, hparams['data_augmentation'], hparams)

--- a/mdlt/scripts/balance_and_train.py
+++ b/mdlt/scripts/balance_and_train.py
@@ -1,0 +1,77 @@
+import argparse
+import os
+import pandas as pd
+import numpy as np
+import subprocess
+
+
+def kl_divergence(counts):
+    probs = counts / counts.sum()
+    uniform = np.ones_like(probs) / len(probs)
+    return float((probs * np.log(probs / uniform + 1e-12)).sum())
+
+
+def balance_dataset(csv_path, ratio=1.0, seed=0):
+    df = pd.read_csv(csv_path)
+    df_train = df[df['split'] == 'train']
+    rng = np.random.RandomState(seed)
+
+    counts = df_train['label'].value_counts().sort_index()
+    min_count = counts.min()
+    target = int(min_count * ratio)
+
+    selected_idx = []
+    for env in df_train['env'].unique():
+        env_df = df_train[df_train['env'] == env]
+        for label in counts.index:
+            label_idx = env_df[env_df['label'] == label].index
+            n = min(target, len(label_idx))
+            if n > 0:
+                selected_idx.extend(rng.choice(label_idx, n, replace=False))
+
+    balanced_df = pd.concat([df.loc[selected_idx], df[df['split'] != 'train']])
+    balanced_df.sort_index(inplace=True)
+    return df, balanced_df
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create balanced subset and train")
+    parser.add_argument('--dataset', type=str, required=True)
+    parser.add_argument('--data_dir', type=str, required=True)
+    parser.add_argument('--output_dir', type=str, default='./output')
+    parser.add_argument('--ratio', type=float, default=1.0,
+                        help='Fraction of the minority class to keep')
+    parser.add_argument('--seed', type=int, default=0)
+    parser.add_argument('--train_steps', type=int, default=None)
+    args = parser.parse_args()
+
+    dset_dir = os.path.join(args.data_dir, args.dataset if args.dataset != 'DomainNet' else 'domain_net')
+    csv_path = os.path.join(dset_dir, f"{args.dataset}.csv")
+    orig_df, bal_df = balance_dataset(csv_path, args.ratio, args.seed)
+
+    orig_counts = orig_df[orig_df['split'] == 'train']['label'].value_counts().sort_index()
+    bal_counts = bal_df[bal_df['split'] == 'train']['label'].value_counts().sort_index()
+    print('Original KL-divergence:', kl_divergence(orig_counts))
+    print('Balanced KL-divergence:', kl_divergence(bal_counts))
+
+    out_csv = os.path.join(dset_dir, f"{args.dataset}_balanced.csv")
+    bal_df.to_csv(out_csv, index=False)
+
+    env = os.environ.copy()
+    env['MDLT_CSV_SUFFIX'] = '_balanced'
+    cmd = [
+        'python', 'mdlt/train.py',
+        '--dataset', args.dataset,
+        '--algorithm', 'ERM',
+        '--output_folder_name', 'balanced',
+        '--data_dir', args.data_dir,
+        '--output_dir', args.output_dir
+    ]
+    if args.train_steps:
+        cmd += ['--steps', str(args.train_steps)]
+
+    subprocess.run(cmd, env=env, check=True)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add environment variable support `MDLT_CSV_SUFFIX` so dataset loaders can read alternate CSV files
- provide `balance_and_train.py` for cutting down data to reduce KL-divergence and training ERM

## Testing
- `python -m py_compile mdlt/scripts/balance_and_train.py mdlt/dataset/datasets.py`

------
https://chatgpt.com/codex/tasks/task_e_6848e2e73724832fbc0f166437013db4