### PR TITLE
Add Slurm launcher for balance_and_train script

### DIFF
--- a/mdlt/dataset/datasets.py
+++ b/mdlt/dataset/datasets.py
@@ -490,10 +490,14 @@ class VLCS(MultipleEnvironmentImageFolder):
     MANY_SHOT_THRES = 100
     FEW_SHOT_THRES = 20
 
+    # If the environment variable ``MDLT_CSV_SUFFIX`` is set, the dataset will
+    # load ``VLCS${MDLT_CSV_SUFFIX}.csv`` instead of the default CSV.
+
     def __init__(self, root, split, hparams):
         self.dir = os.path.join(root, "VLCS")
-        self.df = pd.read_csv(os.path.join(self.dir, "VLCS.csv"))
-        # self.df = pd.read_csv("/home/hyunggyu/imbalance/multi-domain-imbalance/mdlt/dataset/split/VLCS.csv")
+        csv_suffix = os.environ.get("MDLT_CSV_SUFFIX", "")
+        csv_name = f"VLCS{csv_suffix}.csv"
+        self.df = pd.read_csv(os.path.join(self.dir, csv_name))
         super().__init__(self.dir, self.df, split, hparams['data_augmentation'], hparams)
 
 
@@ -501,11 +505,13 @@ class PACS(MultipleEnvironmentImageFolder):
     ENVIRONMENTS = ["A", "C", "P", "S"]
     MANY_SHOT_THRES = 100
     FEW_SHOT_THRES = 20
+    # Use ``MDLT_CSV_SUFFIX`` to select ``PACS${MDLT_CSV_SUFFIX}.csv``
 
     def __init__(self, root, split, hparams):
         self.dir = os.path.join(root, "PACS")
-        self.df = pd.read_csv(os.path.join(self.dir, "PACS.csv"))
-        # self.df = pd.read_csv("/home/hyunggyu/imbalance/multi-domain-imbalance/mdlt/dataset/split/PACS.csv")
+        csv_suffix = os.environ.get("MDLT_CSV_SUFFIX", "")
+        csv_name = f"PACS{csv_suffix}.csv"
+        self.df = pd.read_csv(os.path.join(self.dir, csv_name))
         super().__init__(self.dir, self.df, split, hparams['data_augmentation'], hparams)
 
 
@@ -515,11 +521,13 @@ class DomainNet(MultipleEnvironmentImageFolder):
     ENVIRONMENTS = ["clip", "info", "paint", "quick", "real", "sketch"]
     MANY_SHOT_THRES = 100
     FEW_SHOT_THRES = 20
+    # When ``MDLT_CSV_SUFFIX`` is set, ``DomainNet${MDLT_CSV_SUFFIX}.csv`` is used
 
     def __init__(self, root, split, hparams):
         self.dir = os.path.join(root, "domain_net")
-        self.df = pd.read_csv(os.path.join(self.dir, "DomainNet.csv"))
-        # self.df = pd.read_csv("/home/hyunggyu/imbalance/multi-domain-imbalance/mdlt/dataset/split/DomainNet.csv")
+        csv_suffix = os.environ.get("MDLT_CSV_SUFFIX", "")
+        csv_name = f"DomainNet{csv_suffix}.csv"
+        self.df = pd.read_csv(os.path.join(self.dir, csv_name))
 
         super().__init__(self.dir, self.df, split, hparams['data_augmentation'], hparams)
 
@@ -528,11 +536,13 @@ class OfficeHome(MultipleEnvironmentImageFolder):
     ENVIRONMENTS = ["A", "C", "P", "R"]
     MANY_SHOT_THRES = 60
     FEW_SHOT_THRES = 20
+    # Load ``OfficeHome${MDLT_CSV_SUFFIX}.csv`` when the environment variable is set
 
     def __init__(self, root, split, hparams):
         self.dir = os.path.join(root, "office_home")
-        self.df = pd.read_csv(os.path.join(self.dir, "OfficeHome.csv"))
-        # self.df = pd.read_csv("/home/hyunggyu/imbalance/multi-domain-imbalance/mdlt/dataset/split/OfficeHome.csv")
+        csv_suffix = os.environ.get("MDLT_CSV_SUFFIX", "")
+        csv_name = f"OfficeHome{csv_suffix}.csv"
+        self.df = pd.read_csv(os.path.join(self.dir, csv_name))
         
         super().__init__(self.dir, self.df, split, hparams['data_augmentation'], hparams)
 
@@ -541,9 +551,11 @@ class TerraIncognita(MultipleEnvironmentImageFolder):
     ENVIRONMENTS = ["L100", "L38", "L43", "L46"]
     MANY_SHOT_THRES = 100
     FEW_SHOT_THRES = 25
+    # ``MDLT_CSV_SUFFIX`` selects ``TerraIncognita${MDLT_CSV_SUFFIX}.csv``
 
     def __init__(self, root, split, hparams):
         self.dir = os.path.join(root, "terra_incognita")
-        self.df = pd.read_csv(os.path.join(self.dir, "TerraIncognita.csv"))
-        # self.df = pd.read_csv("/home/hyunggyu/imbalance/multi-domain-imbalance/mdlt/dataset/split/TerraIncognita.csv")
+        csv_suffix = os.environ.get("MDLT_CSV_SUFFIX", "")
+        csv_name = f"TerraIncognita{csv_suffix}.csv"
+        self.df = pd.read_csv(os.path.join(self.dir, csv_name))
         super().__init__(self.dir, self.df, split, hparams['data_augmentation'], hparams)

--- a/mdlt/run_balance_and_train.sh
+++ b/mdlt/run_balance_and_train.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+#SBATCH --job-name=BAL_TRAIN
+#SBATCH --partition=laal_a6000
+#SBATCH --nodes=1
+#SBATCH --gres=gpu:1
+#SBATCH --time=0-12:00:00
+#SBATCH --mem=50GB
+#SBATCH --cpus-per-task=16
+#SBATCH --output=./slurm_logs/S-%x.%j.out
+
+# Change to repository root
+cd "$(dirname "$0")/.."
+
+# Example call to balance dataset and train ERM
+python -m mdlt.scripts.balance_and_train \
+  --dataset PACS \
+  --data_dir /path/to/data \
+  --output_dir ./output \
+  --ratio 1.0 \
+  --seed 0

--- a/mdlt/scripts/balance_and_train.py
+++ b/mdlt/scripts/balance_and_train.py
@@ -1,0 +1,77 @@
+import argparse
+import os
+import pandas as pd
+import numpy as np
+import subprocess
+
+
+def kl_divergence(counts):
+    probs = counts / counts.sum()
+    uniform = np.ones_like(probs) / len(probs)
+    return float((probs * np.log(probs / uniform + 1e-12)).sum())
+
+
+def balance_dataset(csv_path, ratio=1.0, seed=0):
+    df = pd.read_csv(csv_path)
+    df_train = df[df['split'] == 'train']
+    rng = np.random.RandomState(seed)
+
+    counts = df_train['label'].value_counts().sort_index()
+    min_count = counts.min()
+    target = int(min_count * ratio)
+
+    selected_idx = []
+    for env in df_train['env'].unique():
+        env_df = df_train[df_train['env'] == env]
+        for label in counts.index:
+            label_idx = env_df[env_df['label'] == label].index
+            n = min(target, len(label_idx))
+            if n > 0:
+                selected_idx.extend(rng.choice(label_idx, n, replace=False))
+
+    balanced_df = pd.concat([df.loc[selected_idx], df[df['split'] != 'train']])
+    balanced_df.sort_index(inplace=True)
+    return df, balanced_df
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create balanced subset and train")
+    parser.add_argument('--dataset', type=str, required=True)
+    parser.add_argument('--data_dir', type=str, required=True)
+    parser.add_argument('--output_dir', type=str, default='./output')
+    parser.add_argument('--ratio', type=float, default=1.0,
+                        help='Fraction of the minority class to keep')
+    parser.add_argument('--seed', type=int, default=0)
+    parser.add_argument('--train_steps', type=int, default=None)
+    args = parser.parse_args()
+
+    dset_dir = os.path.join(args.data_dir, args.dataset if args.dataset != 'DomainNet' else 'domain_net')
+    csv_path = os.path.join(dset_dir, f"{args.dataset}.csv")
+    orig_df, bal_df = balance_dataset(csv_path, args.ratio, args.seed)
+
+    orig_counts = orig_df[orig_df['split'] == 'train']['label'].value_counts().sort_index()
+    bal_counts = bal_df[bal_df['split'] == 'train']['label'].value_counts().sort_index()
+    print('Original KL-divergence:', kl_divergence(orig_counts))
+    print('Balanced KL-divergence:', kl_divergence(bal_counts))
+
+    out_csv = os.path.join(dset_dir, f"{args.dataset}_balanced.csv")
+    bal_df.to_csv(out_csv, index=False)
+
+    env = os.environ.copy()
+    env['MDLT_CSV_SUFFIX'] = '_balanced'
+    cmd = [
+        'python', 'mdlt/train.py',
+        '--dataset', args.dataset,
+        '--algorithm', 'ERM',
+        '--output_folder_name', 'balanced',
+        '--data_dir', args.data_dir,
+        '--output_dir', args.output_dir
+    ]
+    if args.train_steps:
+        cmd += ['--steps', str(args.train_steps)]
+
+    subprocess.run(cmd, env=env, check=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/mdlt/scripts/imbalance_ratio.py
+++ b/mdlt/scripts/imbalance_ratio.py
@@ -1,0 +1,40 @@
+import argparse
+import os
+import pandas as pd
+
+
+def imbalance_ratio(counts: pd.Series) -> float:
+    return counts.max() / counts.min()
+
+
+def compute_ratios(csv_path: str):
+    df = pd.read_csv(csv_path)
+    df_train = df[df['split'] == 'train']
+
+    label_counts = df_train['label'].value_counts()
+    dataset_ratio = imbalance_ratio(label_counts)
+
+    env_ratios = {}
+    for env in sorted(df_train['env'].unique()):
+        env_counts = df_train[df_train['env'] == env]['label'].value_counts()
+        env_ratios[env] = imbalance_ratio(env_counts)
+    return dataset_ratio, env_ratios
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Compute imbalance ratios for MDLT datasets.')
+    parser.add_argument('--split_dir', default='mdlt/dataset/split', help='Directory containing CSV splits')
+    args = parser.parse_args()
+
+    datasets = ['DomainNet', 'OfficeHome', 'PACS', 'TerraIncognita', 'VLCS']
+    for dset in datasets:
+        csv_path = os.path.join(args.split_dir, f'{dset}.csv')
+        ratio, env_ratios = compute_ratios(csv_path)
+        print(f'{dset}: {ratio:.2f}')
+        for env, r in env_ratios.items():
+            print(f'  {env}: {r:.2f}')
+        print()
+
+
+if __name__ == '__main__':
+    main()

--- a/mdlt/scripts/pairwise_env_kl.py
+++ b/mdlt/scripts/pairwise_env_kl.py
@@ -1,0 +1,52 @@
+import argparse
+import os
+import pandas as pd
+import numpy as np
+import itertools
+
+
+def kl_divergence(p_counts: pd.Series, q_counts: pd.Series) -> float:
+    labels = sorted(set(p_counts.index).union(q_counts.index))
+    p = p_counts.reindex(labels, fill_value=0).astype(float).values
+    q = q_counts.reindex(labels, fill_value=0).astype(float).values
+    p = p / p.sum()
+    q = q / q.sum()
+    eps = 1e-12
+    return float((p * np.log((p + eps) / (q + eps))).sum())
+
+
+def compute_pairwise(csv_path: str):
+    df = pd.read_csv(csv_path)
+    df = df[df['split'] == 'train']
+
+    counts = {
+        env: group['label'].value_counts().sort_index()
+        for env, group in df.groupby('env')
+    }
+    envs = sorted(counts)
+
+    pairs = []
+    for a, b in itertools.combinations(envs, 2):
+        kl_ab = kl_divergence(counts[a], counts[b])
+        kl_ba = kl_divergence(counts[b], counts[a])
+        sym_kl = 0.5 * (kl_ab + kl_ba)
+        pairs.append((a, b, sym_kl))
+    return pairs
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Pairwise KL divergence between environments')
+    parser.add_argument('--split_dir', default='mdlt/dataset/split', help='Directory containing CSV splits')
+    args = parser.parse_args()
+
+    datasets = ['DomainNet', 'OfficeHome', 'PACS', 'TerraIncognita', 'VLCS']
+    for dset in datasets:
+        csv_path = os.path.join(args.split_dir, f'{dset}.csv')
+        print(dset)
+        for env_a, env_b, kl in compute_pairwise(csv_path):
+            print(f'  {env_a} vs {env_b}: {kl:.4f}')
+        print()
+
+
+if __name__ == '__main__':
+    main()

--- a/mdlt/scripts/uniform_class_kl.py
+++ b/mdlt/scripts/uniform_class_kl.py
@@ -1,0 +1,50 @@
+import argparse
+import os
+import pandas as pd
+import numpy as np
+
+
+def kl_divergence(counts: pd.Series, label_set=None) -> float:
+    if label_set is None:
+        label_set = counts.index
+    probs = counts.reindex(label_set, fill_value=0).astype(float).values
+    probs = probs / probs.sum()
+    uniform = np.ones(len(label_set)) / len(label_set)
+    eps = 1e-12
+    return float((probs * np.log((probs + eps) / (uniform + eps))).sum())
+
+
+def compute_kl(csv_path: str):
+    df = pd.read_csv(csv_path)
+    df = df[df['split'] == 'train']
+    label_set = sorted(df['label'].unique())
+
+    dataset_counts = df['label'].value_counts().sort_index()
+    dataset_kl = kl_divergence(dataset_counts, label_set)
+
+    env_kls = {}
+    for env, group in df.groupby('env'):
+        counts = group['label'].value_counts().sort_index()
+        env_kls[env] = kl_divergence(counts, label_set)
+    return dataset_kl, env_kls
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='KL divergence of class distributions vs uniform')
+    parser.add_argument('--split_dir', default='mdlt/dataset/split',
+                        help='Directory containing CSV splits')
+    args = parser.parse_args()
+
+    datasets = ['DomainNet', 'OfficeHome', 'PACS', 'TerraIncognita', 'VLCS']
+    for dset in datasets:
+        csv_path = os.path.join(args.split_dir, f'{dset}.csv')
+        kl_dataset, env_kls = compute_kl(csv_path)
+        print(f'{dset}: {kl_dataset:.4f}')
+        for env, kl in env_kls.items():
+            print(f'  {env}: {kl:.4f}')
+        print()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- provide `run_balance_and_train.sh` example for launching the new balancing utility with Slurm
- retain `MDLT_CSV_SUFFIX` logic for alternate dataset CSVs

## Testing
- `python -m py_compile mdlt/scripts/balance_and_train.py mdlt/dataset/datasets.py`

------
https://chatgpt.com/codex/tasks/task_e_6848e2e73724832fbc0f166437013db4